### PR TITLE
Restore Mesos 1.2 compatibility: Handle AllocationInfo within used resources 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,17 @@ Change Log
 All notable changes to this project are noted in this file. This project adheres to [Semantic
 Versioning](http://semver.org/).
 
-UNRELEASED
-----------
+0.6.0 (2017-10-23)
+------------------
 
-### Bugfix
+### Added
+
+* Add compatibility with Mesos 1.2.0 and the new multi-role support.
+
+### Fixed
 
 * Fixed a bug in the test helpers that caused the test suite to fail if debug symbols were enabled on GCC 4.9.
+
 
 0.5.0 (2017-01-26)
 ------------------

--- a/src/threshold_resource_estimator.cpp
+++ b/src/threshold_resource_estimator.cpp
@@ -90,6 +90,10 @@ ThresholdResourceEstimatorProcess::ThresholdResourceEstimatorProcess(
 {}
 
 Future<Resources> ThresholdResourceEstimatorProcess::oversubscribable() {
+  return usage().then(process::defer(self(), &Self::calcUnusedResources, std::placeholders::_1));
+}
+
+Future<Resources> ThresholdResourceEstimatorProcess::calcUnusedResources(ResourceUsage const& usage) {
   bool cpuOverload = threshold::loadExceedsThreshold(load, loadThreshold);
   bool memOverload = threshold::memExceedsThreshold(memory, memThreshold);
 
@@ -97,10 +101,6 @@ Future<Resources> ThresholdResourceEstimatorProcess::oversubscribable() {
     return Resources();
   }
 
-  return usage().then(process::defer(self(), &Self::calcUnusedResources, std::placeholders::_1));
-}
-
-Future<Resources> ThresholdResourceEstimatorProcess::calcUnusedResources(ResourceUsage const& usage) {
   Resources allocatedRevocable;
   for (auto const& executor : usage.executors()) {
     allocatedRevocable += Resources(executor.allocated()).revocable();

--- a/tests/testutils.hpp
+++ b/tests/testutils.hpp
@@ -35,6 +35,7 @@ public:
         auto* mutable_resource = revocable_executor->add_allocated();
         mutable_resource->CopyFrom(parsed_resource);
         mutable_resource->mutable_revocable(); // mark as revocable
+        mutable_resource->mutable_allocation_info(); // add allocation info object
       }
 
       // always report all memory as actually used
@@ -50,6 +51,7 @@ public:
         auto* mutable_resource = non_revocable_executor->add_allocated();
         mutable_resource->CopyFrom(parsed_resource);
         mutable_resource->clear_revocable(); // mark as non-revocable
+        mutable_resource->mutable_allocation_info(); // add allocation info object
       }
 
       // always report all memory as actually used


### PR DESCRIPTION
Following this change in Mesos 1.2 [1] we need to unset the allocation info of used resources. Otherwise the subtraction to reduce the available oversubscribable resources will be come a no-op, which can lead to overload.

The second additional commit is mostly a cleanup. I was confused by the behaviour while reading the code and debugging.

[1] apache/mesos@7497541

