### PR TITLE
Use Mesos's bundled libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ Change Log
 All notable changes to this project are noted in this file. This project adheres to [Semantic
 Versioning](http://semver.org/).
 
+UNRELEASED
+----------
+
+### Changed
+
+* Use Mesos's bundled libraries by default. This avoids issues when the bundled libraries are incompatible with the ones provided by the Linux distribution.
+
+
 0.6.0 (2017-10-23)
 ------------------
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,11 @@ endif()
 # Find all the dependencies
 #
 
+# prefer Mesos bundled dependencies
+set(MESOS_BUNDLED_LIBRARIES_PREFIX "/usr/lib/mesos/3rdparty" CACHE PATH "The path where the bundled libraries of Mesos are installed.")
+list(INSERT CMAKE_PREFIX_PATH 0 "${MESOS_BUNDLED_LIBRARIES_PREFIX}")
+set(BOOST_ROOT "/usr/lib/mesos/3rdparty")
+
 find_package(Boost REQUIRED)
 find_package(Protobuf REQUIRED)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,6 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF && \
     apt-get install -y \
         cmake \
         g++ \
-        g++-4.9 \
-        libprotobuf-dev \
-        libboost-dev \
-        libgoogle-glog-dev \
         libcurl4-nss-dev \
         libgtest-dev \
         mesos

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,10 +23,6 @@ Vagrant.configure("2") do |config|
     apt-get install -y                     \
         cmake                              \
         g++                                \
-        g++-4.9                            \
-        libprotobuf-dev                    \
-        libboost-dev                       \
-        libgoogle-glog-dev                 \
         libcurl4-nss-dev                   \
         libgtest-dev                       \
         mesos


### PR DESCRIPTION
Mesos uses bundled versions of Boost and Protobuf which are not necessarily compatible with those provided by the system.