### PR TITLE
Support Debian 9 (Stretch)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,10 @@ services:
 
 env:
   matrix:
-    - MESOS_VERSION=1.4.1-2.0.1
-    - MESOS_VERSION=1.3.2-2.0.1
-    - MESOS_VERSION=1.2.3-2.0.1
+    - MESOS_VERSION=1.4.1-2.0.1 DEBIAN_VERSION=stretch
+    - MESOS_VERSION=1.4.1-2.0.1 DEBIAN_VERSION=jessie
+    - MESOS_VERSION=1.3.2-2.0.1 DEBIAN_VERSION=jessie
+    - MESOS_VERSION=1.2.3-2.0.1 DEBIAN_VERSION=jessie
 
 script:
-  - docker build --build-arg MESOS_VERSION=${MESOS_VERSION} .
+  - docker build --build-arg MESOS_VERSION=${MESOS_VERSION} --build-arg DEBIAN_VERSION=${DEBIAN_VERSION} .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](http://semver.org/).
 UNRELEASED
 ----------
 
+### Added
+
+* Debian 9 (Stretch) is now supported.
+
 ### Changed
 
 * Use Mesos's bundled libraries by default. This avoids issues when the bundled libraries are incompatible with the ones provided by the Linux distribution.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,19 @@
-FROM debian:jessie
+ARG DEBIAN_VERSION=stretch
+FROM debian:${DEBIAN_VERSION}
 ARG MESOS_VERSION=1.4.1-2.0.1
 
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF && \
-    echo "deb http://repos.mesosphere.com/debian jessie main" > /etc/apt/sources.list.d/mesosphere.list && \
+ARG DEBIAN_VERSION
+RUN apt-get update && \
+    apt-get install -y gnupg && \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF && \
+    echo deb "http://repos.mesosphere.com/debian ${DEBIAN_VERSION} main" > /etc/apt/sources.list.d/mesosphere.list && \
     apt-get update && \
     apt-get install -y \
         cmake \
         g++ \
         libcurl4-nss-dev \
         libgtest-dev \
+        systemd \
         mesos=${MESOS_VERSION}
 
 ADD . /src

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,29 +3,37 @@
 
 vbox_version = `VBoxManage --version`
 
-Vagrant.configure("2") do |config|
-  config.vm.box = "debian/jessie64"
+machines = ['jessie', 'stretch']
 
-  config.vm.provider "virtualbox" do |vb|
-    vb.memory = "1024"
-    if vbox_version.to_f >= 5.0
-      vb.customize ["modifyvm", :id, "--paravirtprovider", "kvm"]
+Vagrant.configure("2") do |config|
+  machines.each do |os|
+    config.vm.define os do |machine|
+      machine.vm.box = "debian/#{os}64"
+
+      machine.vm.provider "virtualbox" do |vb|
+        vb.memory = "1024"
+        if vbox_version.to_f >= 5.0
+          vb.customize ["modifyvm", :id, "--paravirtprovider", "kvm"]
+        end
+      end
+
+      machine.vm.synced_folder ".", "/vagrant", type: "virtualbox"
+
+      machine.vm.provision "shell", inline: <<-SHELL
+        apt-get update
+        apt-get install -y dirmngr
+
+        apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF
+        echo "deb http://repos.mesosphere.com/debian #{os} main" > /etc/apt/sources.list.d/mesosphere.list
+
+        apt-get update
+        apt-get install -y                     \
+            cmake                              \
+            g++                                \
+            libcurl4-nss-dev                   \
+            libgtest-dev                       \
+            mesos=1.4.1-2.0.1
+      SHELL
     end
   end
-
-  config.vm.synced_folder ".", "/vagrant", type: "virtualbox"
-
-  config.vm.provision "shell", inline: <<-SHELL
-    apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF
-    echo "deb http://repos.mesosphere.com/debian jessie main" > /etc/apt/sources.list.d/mesosphere.list
-
-    apt-get update
-    apt-get install -y                     \
-        cmake                              \
-        g++                                \
-        libcurl4-nss-dev                   \
-        libgtest-dev                       \
-        mesos=1.4.1-2.0.1
-  SHELL
-
 end


### PR DESCRIPTION
* Enables Docker and Vagrant images to run on either Jessie or Stretch.
* Includes a Stretch build in the Travis build.
* Declares support for Stretch in the changelog.